### PR TITLE
Update README.md to include llama-index-llms-ollama in dependency ins…

### DIFF
--- a/rag-with-dockling/README.md
+++ b/rag-with-dockling/README.md
@@ -8,7 +8,7 @@ This project leverages LlamaIndex and IBM's Docling for RAG over excel sheets. Y
 **Install Dependencies**:
    Ensure you have Python 3.11 or later installed.
    ```bash
-   pip install -q --progress-bar off --no-warn-conflicts llama-index-core llama-index-readers-docling llama-index-node-parser-docling llama-index-embeddings-huggingface llama-index-llms-huggingface-api llama-index-readers-file python-dotenv
+   pip install -q --progress-bar off --no-warn-conflicts llama-index-core llama-index-readers-docling llama-index-node-parser-docling llama-index-embeddings-huggingface llama-index-llms-huggingface-api llama-index-readers-file python-dotenv llama-index-llms-ollama
    ```
 
 ---


### PR DESCRIPTION
…tallation pip command

llama-index-llms-ollama is used in from llama_index.llms.ollama import Ollama so I added it to your pip install to resolve dependency issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with new installation instructions
	- Added `llama-index-llms-ollama` to project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->