### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/zep-memory-assistant/uv.lock
+++ b/zep-memory-assistant/uv.lock
@@ -7,7 +7,7 @@ name = "ag2"
 version = "0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyautogen" },
+    { name = "ag2" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/a4/e381efdce4d20bfa0cb73411de83fed3f93db0504c6f5e871bbada10e5db/ag2-0.9.tar.gz", hash = "sha256:766bf9900fbc1a98e3a7d6bd6d41a7bbbac526eb6371aea01ccac7442635d06d", size = 42474, upload_time = "2025-04-25T00:11:34.69Z" }
 wheels = [
@@ -16,7 +16,7 @@ wheels = [
 
 [package.optional-dependencies]
 ollama = [
-    { name = "pyautogen", extra = ["ollama"] },
+    { name = "ag2", extra = ["ollama"] },
 ]
 
 [[package]]
@@ -547,7 +547,7 @@ wheels = [
 ]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -562,9 +562,9 @@ dependencies = [
     { name = "termcolor" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/25/977ff23b28789f17a4fbc2c009805e55ec0cb8a6ab309beebc07a8c5ceff/pyautogen-0.9.tar.gz", hash = "sha256:58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50", size = 3255051, upload_time = "2025-04-25T00:11:21.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/25/977ff23b28789f17a4fbc2c009805e55ec0cb8a6ab309beebc07a8c5ceff/ag2-0.9.tar.gz", hash = "sha256:58763009b6f6f988cdf9bb908c56a61a60c16e772096ab621edf06748fa58e50", size = 3255051, upload_time = "2025-04-25T00:11:21.462Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/7a/2ba1e2787340ed2650d9b4d030c48e5b40b0c08cb8a86716799062c037e1/pyautogen-0.9-py3-none-any.whl", hash = "sha256:b4bef3cc0aee1aa71959aea39b53001a62326682e6f23acb036f90212b3baf5d", size = 781663, upload_time = "2025-04-25T00:11:18.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7a/2ba1e2787340ed2650d9b4d030c48e5b40b0c08cb8a86716799062c037e1/ag2-0.9-py3-none-any.whl", hash = "sha256:b4bef3cc0aee1aa71959aea39b53001a62326682e6f23acb036f90212b3baf5d", size = 781663, upload_time = "2025-04-25T00:11:18.242Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
