### PR TITLE
Fix agentic_rag demos crashing on import (wrong kwarg + hardcoded PDF path)

### DIFF
--- a/agentic_rag/src/agentic_rag/crew.py
+++ b/agentic_rag/src/agentic_rag/crew.py
@@ -1,3 +1,5 @@
+import os
+
 from crewai import Agent, Crew, Process, Task
 from crewai.project import CrewBase, agent, crew, task
 from crewai_tools import SerperDevTool
@@ -5,8 +7,10 @@ from crewai_tools import PDFSearchTool
 # from tools.custom_tool import DocumentSearchTool
 from agentic_rag.tools.custom_tool import DocumentSearchTool
 
-# Initialize the tool with a specific PDF path for exclusive search within that document
-pdf_tool = DocumentSearchTool(pdf='/Users/akshaypachaar/Eigen/ai-engineering/agentic_rag/knowledge/dspy.pdf')
+# Initialize the tool with the bundled PDF, resolved relative to this file so the
+# demo runs on any machine (not just the original author's absolute path).
+PDF_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "knowledge", "dspy.pdf")
+pdf_tool = DocumentSearchTool(file_path=PDF_PATH)
 web_search_tool = SerperDevTool()
 
 @CrewBase

--- a/agentic_rag_deepseek/src/agentic_rag/crew.py
+++ b/agentic_rag_deepseek/src/agentic_rag/crew.py
@@ -1,3 +1,5 @@
+import os
+
 from crewai import Agent, Crew, Process, Task
 from crewai.project import CrewBase, agent, crew, task
 from crewai_tools import SerperDevTool
@@ -5,8 +7,10 @@ from crewai_tools import PDFSearchTool
 # from tools.custom_tool import DocumentSearchTool
 from agentic_rag.tools.custom_tool import DocumentSearchTool
 
-# Initialize the tool with a specific PDF path for exclusive search within that document
-pdf_tool = DocumentSearchTool(pdf='/Users/akshaypachaar/Eigen/ai-engineering/agentic_rag/knowledge/dspy.pdf')
+# Initialize the tool with the bundled PDF, resolved relative to this file so the
+# demo runs on any machine (not just the original author's absolute path).
+PDF_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "knowledge", "dspy.pdf")
+pdf_tool = DocumentSearchTool(file_path=PDF_PATH)
 web_search_tool = SerperDevTool()
 
 @CrewBase


### PR DESCRIPTION
While trying to run the `agentic_rag` demo I hit a `TypeError` the moment the crew module is imported. Digging in, it comes down to the tool being constructed with a keyword that doesn't exist on its constructor.

In `agentic_rag/src/agentic_rag/crew.py` the tool is created like this:

```python
pdf_tool = DocumentSearchTool(pdf='/Users/akshaypachaar/Eigen/ai-engineering/agentic_rag/knowledge/dspy.pdf')
```

but `DocumentSearchTool.__init__` (in `tools/custom_tool.py`) is actually defined as:

```python
def __init__(self, file_path: str):
```

There is no `pdf` parameter, so importing `crew.py` fails with `TypeError: __init__() got an unexpected keyword argument 'pdf'`. Because that line runs at module load time, the demo can't even start.

There's a second problem hiding behind it: the PDF path is hardcoded to the original author's machine (`/Users/akshaypachaar/...`). So even once the keyword is fixed, it would still fail with `FileNotFoundError` for anyone else — even though each demo already ships its own copy at `knowledge/dspy.pdf`.

The exact same two issues exist in the `agentic_rag_deepseek` variant, so I fixed both.

**What changed**

- Pass `file_path=` instead of the non-existent `pdf=` kwarg.
- Resolve the bundled `knowledge/dspy.pdf` relative to `crew.py` with `os.path`, so it works no matter where the repo is cloned instead of pointing at one person's home directory.

Diff is small (2 files, the two `crew.py` entry points). Both modules now import cleanly and pick up the PDF that's already in each demo's `knowledge/` folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed PDF file path resolution by switching from hardcoded absolute paths to runtime relative path computation, so the bundled PDF can be found correctly across different machines and environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->