### PR TITLE
Fix Corrective-RAG never triggering web search (exact-match grade parsing)

### DIFF
--- a/corrective-rag/workflow.py
+++ b/corrective-rag/workflow.py
@@ -127,13 +127,21 @@ class CorrectiveRAGWorkflow(Workflow):
             relevancy = self.llm.complete(prompt)
             relevancy_results.append(relevancy.text.lower().strip())
 
+        # The grader is asked for a binary 'yes'/'no', but LLMs often add
+        # punctuation or a short justification (e.g. "No, ..."). Match on the
+        # leading token so the decision is robust instead of requiring the result
+        # to be exactly "yes"/"no".
         relevant_texts = [
             retrieved_nodes[i].text
             for i, result in enumerate(relevancy_results)
-            if result == "yes"
+            if result.startswith("yes")
         ]
         relevant_text = "\n".join(relevant_texts)
-        if "no" in relevancy_results:
+        # Trigger a corrective web search whenever at least one retrieved document
+        # was judged not relevant (anything that isn't a clear "yes"). The previous
+        # `"no" in relevancy_results` only matched a result that was exactly "no",
+        # so answers like "No, ..." or "no." silently skipped the web search.
+        if any(not result.startswith("yes") for result in relevancy_results):
             return WebSearchEvent(relevant_text=relevant_text)
         else:
             return QueryEvent(relevant_text=relevant_text, search_text="")

--- a/firecrawl-agent/workflow.py
+++ b/firecrawl-agent/workflow.py
@@ -180,7 +180,12 @@ class CorrectiveRAGWorkflow(Workflow):
         print(f"DEBUG: Relevant texts count: {len(relevant_texts)}")
         print(f"DEBUG: Relevant text preview: {relevant_text[:200]}...")
         
-        if "no" in relevancy_results_striped:
+        # A document is treated as relevant when its grade contains "yes" (see the
+        # filter above), so trigger a corrective web search whenever any document is
+        # *not* relevant. The previous `"no" in relevancy_results_striped` only
+        # matched a grade equal to exactly "no", so answers like "No, ..." or "no."
+        # silently skipped the web search.
+        if any("yes" not in result.lower() for result in relevancy_results_striped):
             print("DEBUG: Some documents irrelevant, returning WebSearchEvent")
             return WebSearchEvent(relevant_text=relevant_text)
         else:


### PR DESCRIPTION
The Corrective-RAG demos never actually run their corrective web search, because the trigger condition can't match real LLM output.

In `corrective-rag/workflow.py` (and the same logic in `firecrawl-agent/workflow.py`), each retrieved document is graded by an LLM and the full response is stored:

```python
relevancy_results.append(relevancy.text.lower().strip())
```

The decision to do a web search is then:

```python
if "no" in relevancy_results:
    return WebSearchEvent(...)
```

`relevancy_results` is a list of full grader responses, so `"no" in relevancy_results` is a membership test that is only true when a response is *exactly* the string `"no"`. The grading prompt asks for a binary `yes`/`no`, but in practice the model replies with things like `"no."`, `"No, the document is not relevant"`, etc. None of those equal `"no"`, so the condition is almost never true and the corrective web search is silently skipped — the core Corrective-RAG behavior doesn't fire.

`corrective-rag` has the same issue on the relevant-doc filter (`result == "yes"`), which drops any document whose grade isn't exactly `"yes"` (e.g. `"yes, relevant"`).

Fix — make the grade parsing robust instead of exact-match:

- **corrective-rag**: a document is relevant when its grade starts with `"yes"`, and the web search triggers when *any* document is not a clear `"yes"`.
- **firecrawl-agent**: it already treats a document as relevant when the grade contains `"yes"`, so I made the trigger consistent with that — web search when *any* document's grade does not contain `"yes"`. (It had switched the relevant-doc filter to fuzzy matching but left the `"no" in ...` trigger as exact, so the two were inconsistent.)

Easy way to see it before the fix: grade an irrelevant document so the model answers `"No, ..."` — the old code returns `QueryEvent` (no web search) instead of `WebSearchEvent`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relevancy evaluation to be more tolerant of varied language model output formatting, ensuring corrective web searches are reliably triggered for irrelevant content regardless of response capitalization or punctuation variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->