### PR TITLE
Fix: resolve gql dependency error by pinning version in mcp_rl (Fixes…

### DIFF
--- a/art_mcp_rl/mcp_rl.ipynb
+++ b/art_mcp_rl/mcp_rl.ipynb
@@ -117,11 +117,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
-        "!uv pip install fastmcp --quiet"
+        "!uv pip install fastmcp \"gql>=4.0.0\" --quiet"
       ]
     },
     {


### PR DESCRIPTION
### Description
This PR resolves the `ImportError: cannot import name 'TransportConnectionFailed'` that occurs when running the `mcp_rl.ipynb` notebook in Google Colab. 

The issue stems from a dependency mismatch where `weave` expects `TransportConnectionFailed` to be exposed, but the environment pulls an incompatible beta version of `gql` (`3.6.0b4`). 

### Changes Made
- Modified the initialization cell in `mcp_rl.ipynb` to explicitly pin `gql>=4.0.0` using `uv pip install` before other dependencies are pulled.

Fixes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the notebook’s setup step to install the required packages more reliably.
  * Added a version constraint for a dependency and kept installation output quieter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->